### PR TITLE
Feature filtering update

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,3 +1,3 @@
 Package: soda
 Title: Simple Omics Data Analysis
-Version: 0.2.15
+Version: 0.2.16

--- a/R/soda_global_functions.R
+++ b/R/soda_global_functions.R
@@ -24,11 +24,12 @@ remove_empty_cols = function(table) {
   del_cols = c()
   for (col in colnames(table)) {
     if (sum(is.na(table[,col])) == length(rownames(table))){
-      # table[,col] = NULL
       del_cols = c(del_cols, col)
     }
   }
-  table = table[,-which(colnames(table) %in% del_cols)]
+  if (!is.null(del_cols)) {
+    table = table[,-which(colnames(table) %in% del_cols)]
+  }
   return(table)
 }
 
@@ -192,10 +193,9 @@ get_subplot_titles = function(class_list){
 
 #----------------------------------------- Lipid upload class preview plots ----
 
-preview_class_plot = function(data_table, del_cols){
+preview_class_plot = function(data_table, del_cols, feat_raw){
 
-  total_values = table(get_lipid_classes(feature_list = colnames(data_table),
-                                         uniques = F))
+  total_values = table(feat_raw$lipid_class)
   filtered_values_1 = rep(0,each=length(total_values))
   names(filtered_values_1) = names(total_values)
 
@@ -217,6 +217,7 @@ preview_class_plot = function(data_table, del_cols){
 
   lip_val = c(rep(100, length(total_values)) - round(100*(filtered_values_1/total_values),1), round(100*(filtered_values_1/total_values),1))
   class_df = data.frame(lip_class, d_type, lip_val)
+  class_df[, "lip_val"] = round(class_df[, "lip_val"],1)
 
   lip_val_abs = c(total_values - filtered_values_1, filtered_values_1)
   class_df_abs = data.frame(lip_class, d_type, lip_val_abs)

--- a/R/soda_omics_data_class.R
+++ b/R/soda_omics_data_class.R
@@ -48,6 +48,7 @@ Omics_data = R6::R6Class(
       # Filtered
       meta_filtered = NULL,
       data_filtered = NULL,
+      feat_raw = NULL,
       feat_filtered = NULL,
 
       # Normalised
@@ -245,7 +246,10 @@ Omics_data = R6::R6Class(
         table = remove_empty_cols(table)
       }
 
-      self$tables$data_filtered = as.matrix(table)
+      # Coerce to numeric matrix and save
+      table = as.matrix(table)
+      class(table) = "numeric"
+      self$tables$data_filtered = table
     },
 
     # Set or reset the filtered Metadata
@@ -268,7 +272,14 @@ Omics_data = R6::R6Class(
       
     },
 
-    # Set feature table
+    # Set feature tables
+    set_feat_raw = function() {
+      id_col = self$texts$col_id_data
+      data_table = self$tables$data_raw
+      rownames(data_table) = data_table[,id_col]
+      data_table = data_table[,-which(colnames(data_table) == id_col)]
+      self$tables$feat_raw = get_feature_metadata(data_table = data_table)
+    },
     set_feat_filtered = function() {
       self$tables$feat_filtered = get_feature_metadata(data_table = self$tables$data_filtered)
     },
@@ -307,10 +318,9 @@ Omics_data = R6::R6Class(
                                   blank_multiplier = blank_multiplier,
                                   group_threshold = group_threshold)
         del_cols = setdiff(del_cols,saved_cols)
-        if (length(del_cols) == 0) {del_cols = NULL}
       }
 
-      if (!is.null(del_cols)) {
+      if (length(del_cols) > 0) {
         self$tables$data_filtered = self$tables$data_filtered[,!(colnames(self$tables$data_filtered) %in% del_cols)]
       }
     },

--- a/help/tables_feature_metadata.md
+++ b/help/tables_feature_metadata.md
@@ -4,6 +4,12 @@ Feature tables
 
 Tables related to the feature metadata, stored in the Omics_data class.  
 
+### Raw feature table  
+Tool tip missing.   
+```
+Omics_data$tables$feat_raw
+```
+
 ### Filtered feature table  
 Updated version of the *Raw feature table* using the features available in the *Filtered data table*. This is the main feature table that will be used when mapping feature metadata.  
 This table can be accessed in the Omics_data object thus:  


### PR DESCRIPTION
Coerced data_filtered matrix to numeric just in case. Rounded preview plot numbers
Solved the "-3" bug (three columns getting filtered out when dropping no columns in the feature filter, those were actually fully NA columns that were filtered out when initiating data_filtered, but the original feature count progress bar did not take them into account, not did the "Reset table" column, making it so that the max feature count changed along the way when manipulating the data). Improved the preview table to now also display fully emptied classes. It now takes as max the lipid classes from the feature table raw. Improvement the manual selection in the feature filter to update the choices according to the current data_filtered AND the blank and group filtering parameters currently selected. Solved the "keep bug" : keep button not taking into account the group filtering in the preview table and the progress bar. Solved the "empty feature selection" bug, where doing keep on an empty selection would just erase the table. Now when selection is empty: does nothing.