### PR TITLE
Minor patches.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,3 +1,3 @@
 Package: soda
 Title: Simple Omics Data Analysis
-Version: 0.2.17
+Version: 0.2.18

--- a/R/soda_help.R
+++ b/R/soda_help.R
@@ -5,6 +5,7 @@ soda_help = function(help_file){
 	shiny::includeMarkdown(paste0("./help/", help_file, ".md"))
 }
 
+#--------------------------------------------------------- Data upload help ----
 soda_help_data_upload = function(){
   bs4Dash::tabsetPanel(
     type = "tabs",
@@ -31,7 +32,7 @@ soda_help_data_upload = function(){
   )
 }
 
-
+#-------------------------------------------------- Data visualisation help ----
 soda_help_data_visualisation = function(){
   bs4Dash::tabsetPanel(
     type = "tabs",
@@ -62,6 +63,7 @@ soda_help_data_visualisation = function(){
   )
 }
 
+#--------------------------------------------------------- Data tables help ----
 soda_help_tables = function(){
   bs4Dash::tabsetPanel(
     type = "tabs",
@@ -72,6 +74,10 @@ soda_help_tables = function(){
     shiny::tabPanel(
       title = "Lipidomics tables",
       soda_help("tables_lipidomics")
+    ),
+    shiny::tabPanel(
+      title = "Non-samples tables",
+      soda_help("tables_non_samples")
     ),
     shiny::tabPanel(
       title = "Feature tables",

--- a/R/soda_plotboxes.R
+++ b/R/soda_plotboxes.R
@@ -6,6 +6,15 @@ table_switch = function(selection, r6){
          "Total normalised data table" = r6$tables$data_total_norm
   )
 }
+
+z_score_table_switch = function(selection, r6){
+  switch(EXPR = selection,
+         "Filtered data table" = r6$tables$data_z_scored,
+         "Class normalised data table" = r6$tables$data_class_norm_z_scored,
+         "Total normalised data table" = r6$tables$data_total_norm_z_scored
+  )
+}
+
 #----------------------------------------------- Plotting function controls ----
 
 plotbox_switch_ui = function(selection_list){
@@ -315,13 +324,15 @@ volcano_plot_server = function(r6, colour_list, dimensions_obj, input, output, s
       }
 
       r6$get_volcano_table(data_table = table_switch(selection = input$volcano_plot_tables, r6 = r6),
-                           data_table_normalised = r6$tables$data_z_scored,
+                           data_table_normalised = z_score_table_switch(selection = input$volcano_plot_tables, r6 = r6),
                            col_group = input$volcano_plot_metacol,
                            group_1 = input$volcano_plot_metagroup[1],
                            group_2 = input$volcano_plot_metagroup[2])
       
       r6$plot_volcano(data_table = r6$tables$volcano_table,
                       colour_list = colour_list,
+                      group_1 = input$volcano_plot_metagroup[1],
+                      group_2 = input$volcano_plot_metagroup[2],
                       width = width,
                       height = height)
       output$volcano_plot_plot = plotly::renderPlotly(
@@ -715,7 +726,7 @@ double_bonds_server = function(r6, colour_list, dimensions_obj, input, output, s
       }
       
       r6$get_dbplot_table(data_table = table_switch(selection = input$double_bonds_tables, r6 = r6),
-                          data_table_normalised = r6$tables$data_z_scored,
+                          data_table_normalised = z_score_table_switch(selection = input$double_bonds_tables, r6 = r6),
                           dbplot_table = r6$tables$feat_filtered,
                           col_group = input$double_bonds_metacol,
                           group_1 = input$double_bonds_metagroup[1],
@@ -741,6 +752,8 @@ double_bonds_server = function(r6, colour_list, dimensions_obj, input, output, s
       r6$plot_doublebonds(lipid_class = input$double_bonds_class,
                           fc_limits = input$log2_fc_slider,
                           pval_limits = input$min_log10_bh_pval_slider,
+                          group_1 = input$double_bonds_metagroup[1],
+                          group_2 = input$double_bonds_metagroup[2],
                           width = width,
                           height = height)
       output$double_bonds_plot = plotly::renderPlotly(

--- a/help/data_upload_lipidomics_filter.md
+++ b/help/data_upload_lipidomics_filter.md
@@ -1,24 +1,48 @@
 Lipidomics filter tab
 =======================
 ---
+<details>
+<summary><b> Filtering </b></summary>
 
 Tab to filter out features and keep only the significant ones.  
-
-1. **Feature count**
+1. **Feature count**  
 Features remaining in the *Lipidomics filtered table* after filtering.  
-2. **Feature filtering**
+2. **Feature filtering**  
 Select either lipid classes or lipid compounds individually, and then choose either to drop them (remove them) or to keep them (remove everything else).  
-3. **Blank and Group filtering**
-This is used to remove features that are not significantly above blank.  
+3. **Blank and Group filtering**  
+This is used to remove features that are not significantly above blank. For more details, see the Data processing section below.  
 - Blank multiplier: for a given feature, number of times above the blank mean each sample must be to be considered a significative value.  
-- Sample threshold: for a given feautre, proportion of the total amount of samples that must be above the blank values x blank multiplier for that feature to be kept.  
-- Group threshold: secondary threshold for the main group of interest. Works like "Sample threshold" but instead of being in proportion to the total amount of samples, it will be in proportion to the number of samples in each group.  
+- Sample threshold: for a given feautre, ratio of the total amount of samples that must be above the blank values x blank multiplier for that feature to be kept.  
+- Group threshold: secondary threshold for the main groups of interest. Works like "Sample threshold" but instead of being in proportion to the total amount of samples, it will be in proportion to the number of samples in each group.  
 4. **Save or Reset buttons**  
 - The save button saves the filtering to the *Lipidomics filtered table*  
 - The reset button reverts the *Lipidomics filtered table* to its original imported state.  
-5. **Class preview plots**
+5. **Class preview plots**  
 Two bar plots displaying the absolute and relative compound count per lipid class. The first one is absolute count, with the total compounds in each class and the remaining count after filtering. The second one is the relative count, displaying the percentage of compounds remaining in each class after filtering.  
 6. **Download filtered data button**  
 Downloads the *Lipidomics filtered table* as a CSV file.  
 
 <img src="./img/upload_lips_filter.png" width="100%">
+
+</details>
+
+
+<details>
+<summary><b> Data processing </b></summary>
+
+**Blank and Group filtering**.  
+Removes features that are not significantly above blanks. It is applied using the following method:  
+```
+Omics_data$feature_filter(blank_multiplier, sample_threshold, group_threshold)
+```
+This method updates the *Filtered data table* (created at import) by removing non-significant features. It uses itself two functions: blank_filter and group_filter.  
+1. **blank_filter**.  
+Takes as input the initial *Filtered data table*, the *Blank table*, blank_multiplier, and sample_threshold. This function returns a list of features that will be set for deletion (del_cols).  
+Missing values from the *Filtered data table* are imputed by 0. Feature means are calculated from the *Blank table*. Features with only missing values will have their mean set to 0. These means multiplied by the blank_multiplier will constitute the threshold. For each feature, the ratio of samples above threshold is calculated and if that ratio is strictly below the sample_threshold, the feature is set for deletion.  
+2. **group_filter**.  
+Takes as input the initial *Filtered data table*, the *Blank table*, the *Filtered metadata table*, del_cols (see above), the group column name, the blank_multiplier and the group_threshold. It returns a list of columns to be saved from deletion from inside del_cols (saved_cols).  
+Missing values in the *Filtered data table* are ignored (same as 0 imputation). Feature means are calculated from the *Blank table* as before, missing values being set to 0 and all means multiplied by the blank_multiplier to constitute the threshold. This time, the ratio of samples is calculated for each sample group and if any of the groups has a ratio above or equal to the group_threshold, the feature is saved from deletion.  
+  
+The saved_cols are then removed from the del_cols and the remaining del_cols are removed from the *Filtered data table*.  
+</details>
+

--- a/help/data_visualisation_double_bond_plot.md
+++ b/help/data_visualisation_double_bond_plot.md
@@ -1,7 +1,9 @@
 Double bond plot
 =======================
 ---
-### Plot and interface
+<details>
+<summary><b> Plot and interface </b></summary>
+
 Plot comparing two samples based on their lipid species.  
 1. **Select data table.**  
 Select the data to be used for comparison among the following: *Filtered data table*, *Class normalised data table*, *Total normalised data table*
@@ -24,8 +26,12 @@ Sliders allow a better exploration of the data, especially when markers are stac
 <img src="./img/visualise_lips_dbplot_1.png" width="49%">
 <img src="./img/visualise_lips_dbplot_2.png" width="49%">
 
-### Data processing
-**Tables used:** {*Filtered data table*, *Class normalised data table*, *Total normalised data table*}, *Z-scored data table*, *Filtered feature table*.  
+</details>
+
+<details>
+<summary><b> Data processing </b></summary>
+
+**Tables used:** {*Filtered data table*, *Class normalised data table*, *Total normalised data table*}, {*Z-scored data table*, *Z-scored class normalised data table*, *Z-scored total normalised data table*}, *Filtered feature table*.  
 Samples of the two groups are selected and for each feature in the *Filtered feature table*, p-values and fold changes are calculated.  
   
 The fold change is calculated from the selected data table (one of *Filtered data table*, *Class normalised data table*, *Total normalised data table*) using the median value of the second group divided by the median value of the first group, ignoring missing values. In case of groups containing only missing values: 
@@ -38,10 +44,12 @@ In the case of medians being 0:
 - Nominator median is 0, fold change becomes 0. 0s are replaced to a value slighlty below the minimum fold change, i.e. 0.99 x min fold change (low value divided by high value).  
 - Both nominator and denominator are 0, fold change becomes NA. These are set to 1.  
 
-The p-value is calculated using a Wilcoxon test on the z-score normalised values (*Z-scored data table*) between group 1 and group 2 for a given feature. In case of groups containing only NAs:  
+The p-value is calculated using a Wilcoxon test on the z-scored table (one of *Z-scored data table*, *Z-scored class normalised data table*, *Z-scored total normalised data table*) between group 1 and group 2 for a given feature. In case of groups containing only NAs:  
 - Both groups contain only NAs, the p-value is by default set to 1 (low values in both groups).  
 - One group contains only NAs, the p-value is set to slightly below the minimum p-value, i.e. 0.99 x min p-value (low values compared to high values).  
 
 The p-value is then adjusted using the Benjamini-Hochberg procedure.  
 
 The *Double bonds table* is then produced from the *Filtered feature table* (containing feature metadata) and adding log2(fold change) and -log10(BH(p-value)).    
+</details>
+

--- a/help/data_visualisation_heatmap.md
+++ b/help/data_visualisation_heatmap.md
@@ -1,7 +1,8 @@
 Heatmap
 =======================
 ---
-### Plot and interface
+<details>
+<summary><b> Plot and interface </b></summary>
 Plot to visualise correlations between samples and features. Two datasets can be selected from the sidebar, either lipid species (individual compounds) or lipid classes. Samples and features can be left in their original order, or clustered by ticking either one or both "Cluster samples" and "Cluster features" boxes.  
 Metadata can be mapped on the heatmap x- and y-axes to observe more correlations. "Map sample data" allows a selection of one or more metadata columns to be mapped on the sample axis. "Map feature data" allows a selection of one or more columns from the *Filtered feature table*, i.e. lipid class, carbon count or unsaturation count.  
 The "Percentile" slider allows a filtering of the data from the 90th to the 100th percentile to prevent outliers from disrupting the heatmap colouring. Choosing the 95th percentile means that 95% of the data will be displayed, i.e. the top 2.5% and bottom 2.5% will be excluded from the colour scale.  
@@ -11,7 +12,11 @@ The individual values can be examined by hovering the mouse over each cell, howe
 <img src="./img/visualise_lips_heatmap_1.png" width="49%">
 <img src="./img/visualise_lips_heatmap_2.png" width="49%">
 
-### Data processing
+</details>
+
+<details>
+<summary><b> Data processing </b></summary>
 Two tables can be selected, *Total normalised and z-score data table* or *Total normalised and z-scored class table*, respectively the normalised lipid species or lipid classes.  
 Using the percentile slider, the maximum and minimum values of the colour coding are set from the selected table. The midpoint is set to the median of all the values. The values are then displayed directly on the heatmap.  
+</details>
 

--- a/help/data_visualisation_pca.md
+++ b/help/data_visualisation_pca.md
@@ -1,12 +1,18 @@
 PCA
 =======================
 ---
-### Plot and interface
+<details>
+<summary><b> Plot and interface </b></summary>
 Plot to observe correlations between sample groups. Two datasets can be selected from the sidebar, either lipid species (individual compounds) or lipid classes. Data points in the scores plot can be coloured by groups using the "Select metadata column" selector. The loadings plot displays which variables cause the observed clustering. Both scores and loadings tables can be downloaded via their respective download buttons.  
 
 <img src="./img/visualise_lips_pca_1.png" width="49%">
 <img src="./img/visualise_lips_pca_2.png" width="49%">
 
-### Data processing
+</details>
+
+<details>
+<summary><b> Data processing </b></summary>
+
 Two tables can be selected, *Total normalised and z-score data table* or *Total normalised and z-scored class table*, respectively the normalised lipid species or lipid classes. Loadings and scores are calculated for PC1 and PC2, and the data is displayed in the form of scatter plots.  
+</details>
 

--- a/help/data_visualisation_volcano_plot.md
+++ b/help/data_visualisation_volcano_plot.md
@@ -1,7 +1,9 @@
 Volcano plot
 =======================
 ---
-### Plot and interface
+<details>
+<summary><b> Plot and interface </b></summary>  
+
 Plot used to visualise the differences in lipid composition between two sample groups. 
 1. **Select data table.**  
 Select the data to be used for comparison among the following: *Filtered data table*, *Class normalised data table*, *Total normalised data table*
@@ -18,8 +20,12 @@ In volcano plots, data points situated on the top of the graph are more signific
 <img src="./img/visualise_lips_volcano_plot_1.png" width="49%">
 <img src="./img/visualise_lips_volcano_plot_2.png" width="49%">
 
-### Data processing
-**Tables used:** {*Filtered data table*, *Class normalised data table*, *Total normalised data table*}, *Z-scored data table*, *Filtered feature table*.  
+</details>
+
+<details>
+<summary><b> Data processing </b></summary>
+
+**Tables used:** {*Filtered data table*, *Class normalised data table*, *Total normalised data table*}, {*Z-scored data table*, *Z-scored class normalised data table*, *Z-scored total normalised data table*}, *Filtered feature table*.  
 Samples of the two groups are selected and for each feature in the *Filtered feature table*, p-values and fold changes are calculated.  
   
 The fold change is calculated from the selected data table (one of *Filtered data table*, *Class normalised data table*, *Total normalised data table*) using the median value of the second group divided by the median value of the first group, ignoring missing values. In case of groups containing only missing values: 
@@ -32,10 +38,13 @@ In the case of medians being 0:
 - Nominator median is 0, fold change becomes 0. 0s are replaced to a value slighlty below the minimum fold change, i.e. 0.99 x min fold change (low value divided by high value).  
 - Both nominator and denominator are 0, fold change becomes NA. These are set to 1.  
 
-The p-value is calculated using a Wilcoxon test on the z-score normalised values (*Z-scored data table*) between group 1 and group 2 for a given feature. In case of groups containing only NAs:  
+The p-value is calculated using a Wilcoxon test on the z-scored table (one of *Z-scored data table*, *Z-scored class normalised data table*, *Z-scored total normalised data table*) between group 1 and group 2 for a given feature. In case of groups containing only NAs:  
 - Both groups contain only NAs, the p-value is by default set to 1 (low values in both groups).  
 - One group contains only NAs, the p-value is set to slightly below the minimum p-value, i.e. 0.99 x min p-value (low values compared to high values).  
 
 The p-value is then adjusted using the Benjamini-Hochberg procedure.  
 
 The *Volcano table* is then produced by calculating the log2(fold change) to be displayed on the x-axis, and -log10(BH(p-value)) to be displayed on the y-axis.  
+
+</details>
+

--- a/help/tables_classes.md
+++ b/help/tables_classes.md
@@ -3,15 +3,20 @@ Class tables
 ---
 
 Tables related to the lipid classes, stored in the Omics_data class.  
+<details>
+<summary><b> Total normalised class table </b></summary>
 
-### Total normalised class table
 A class table is produced by getting all the lipid classes from the lipidomics total normalised table to total lipids to obtain a sample x lipid class table. For each sample, the class value is calculated by summing the values of the lipid species of that class in that sample. NA values are imputed by 0.  
 ```
 Omics_data$tables$data_class_table
 ```
+</details>
 
-### Total normalised and z-scored class table
+<details>
+<summary><b> Total normalised and z-scored class table </b></summary>
 
 ```
 Omics_data$tables$data_class_table_z_scored
 ```
+</details>
+

--- a/help/tables_feature_metadata.md
+++ b/help/tables_feature_metadata.md
@@ -4,16 +4,22 @@ Feature tables
 
 Tables related to the feature metadata, stored in the Omics_data class.  
 
-### Raw feature table  
+<details>
+<summary><b> Raw feature table </b></summary>  
+
 Tool tip missing.   
 ```
 Omics_data$tables$feat_raw
 ```
+</details>
 
-### Filtered feature table  
+<details>
+<summary><b> Filtered feature table </b></summary>  
+
 Updated version of the *Raw feature table* using the features available in the *Filtered data table*. This is the main feature table that will be used when mapping feature metadata.  
 This table can be accessed in the Omics_data object thus:  
 ```
 Omics_data$tables$feat_filtered
 ```
 It is automatically generated with the *Filtered data table* and updated each time the features are filtered.  
+</details>

--- a/help/tables_lipidomics.md
+++ b/help/tables_lipidomics.md
@@ -3,8 +3,9 @@ Lipidomics tables
 ---
 
 Tables related to the lipidomics data, stored in the Omics_data class.  
+<details>
+<summary><b> Raw data table </b></summary>
 
-### Raw data table
 Imported lipidomics table. This contains the concentration of each lipid compound / species detected in each sample. The molecule names are formatted in a specific way so as to extract their lipid class, carbon and unsaturation counts easily. This table can contain NA values. The only mandatory column is a form of *ID* column containing sample IDs present in the *Raw metadata table*.  
 
 The Raw data table can be accessed in the Omics_data object thus:  
@@ -12,53 +13,72 @@ The Raw data table can be accessed in the Omics_data object thus:
 Omics_data$tables$data_raw
 ```
 It is first initiated when the user uploads their lipidomics data table in the *Lipidomics* upload tab. It is mostly used to generate the filtered version and store the original data so that the user can start again the processing using the availbable reset buttons.  
+</details>
 
-### Filtered data table
+<details>
+<summary><b> Filtered data table </b></summary>
+
 Updated version of the *Raw data table* after setting an ID column, and is automatically filtered to contain only the rows present in the *Filtered meta table*. It is then further filtered in the *Lipidomics filter* tab, by filtering out features using the *Blank & Group filtering* and the *feature filters*.  
 This table can be accessed in the Omics_data object thus:  
 ```
 Omics_data$tables$data_filtered
 ```
 It is created as soon as an ID column is selected in the *Lipidomics upload* tab, and further modified with the filtering.  
+</details>
 
-### Z-scored data table
-Z-scoring applied to the *Filtered data table* to normalise the data. NA values are left untouched (NA) and the mean values are calculated by omiting NA values.  
-This table can be accessed in the Omics_data object thus:  
-```
-Omics_data$tables$data_z_scored
-```
-It is automatically generated with the *Filtered data table* and updated each time the features are filtered.  
+<details>
+<summary><b> Class normalised data table </b></summary>
 
-### Class normalised data table
 Data from the *Filtered data table* normalised to the lipid classes of that sample.  The values for each lipid are divided by the summed values of all lipids of the same class. NAs are imputed by 0.  
 This table can be accessed in the Omics_data object thus:  
 ```
 Omics_data$tables$data_class_norm
 ```
 It is automatically generated with the *Filtered data table* and updated each time the features are filtered.  
+</details>
 
-### Total normalised data table
+<details>
+<summary><b> Total normalised data table </b></summary>
+
 Data from the *Filtered data table* normalised to the total lipid content of that sample. Each value is divided by its row sum.  
 This table can be accessed in the Omics_data object thus:  
 ```
 Omics_data$tables$data_total_norm
 ```
 It is automatically generated with the *Filtered data table* and updated each time the features are filtered.  
+</details>
 
-### Class normalised and z-scored data table
+<details>
+<summary><b> Z-scored data table </b></summary>
+
+Z-scoring applied to the *Filtered data table* to normalise the data. NA values are left untouched (NA) and the mean values are calculated by omiting NA values.  
+This table can be accessed in the Omics_data object thus:  
+```
+Omics_data$tables$data_z_scored
+```
+It is automatically generated with the *Filtered data table* and updated each time the features are filtered.  
+</details>
+
+<details>
+<summary><b> Z-scored class normalised data table </b></summary>
+
 Z-scoring applied to the *Class normalised data table* to normalise further the data.  
 This table can be accessed in the Omics_data object thus:  
 ```
 Omics_data$tables$data_class_norm_z_scored
 ```
 It is automatically generated with the *Filtered data table* and updated each time the features are filtered.  
+</details>
 
-### Total normalised and z-scored data table
+<details>
+<summary><b> Z-scored total normalised data table </b></summary>
+
 Z-scoring applied to the *Total normalised data table* to normalise further the data.  
 This table can be accessed in the Omics_data object thus:  
 ```
 Omics_data$tables$data_total_norm_z_scored
 ```
 It is automatically generated with the *Filtered data table* and updated each time the features are filtered.  
+</details>
 
 

--- a/help/tables_metadata.md
+++ b/help/tables_metadata.md
@@ -3,8 +3,9 @@ Metadata tables
 ---
 
 Tables related to the sample metadata, stored in the Omics_data class.  
+<details>
+<summary><b> Raw metadata table </b></summary>
 
-### Raw metadata table
 Imported sample metadata table. It should not contain any NA values. Typically recommended columns include:  
 - *ID*, column containing the unique identifier for each row, tying the sample metadata to the rows in the other data tables.  
 - *Sample_type*, i.e. whether row is an actual sample, a QC, a blank or a pool sample. The type of each sample should also be specified here, like the cell type for example.  
@@ -22,10 +23,14 @@ The Raw metadata raw table can be accessed in the Omics_data object thus:
 Omics_data$tables$meta_raw
 ```
 It is first initiated when the user uploads their metadata table in the *Metadata* upload tab. It is mostly used to generate the filtered version and store the original data so that the user can start again the processing using the availbable reset buttons.  
+</details>
 
-### Filtered metadata table
+<details>
+<summary><b> Filtered metadata table </b></summary>
+
 Updated version of the *Raw metadata table* after setting an ID column and filtering using the *Metadata filter* tab. Typically this table has no longer blank, QC and pool samples, which remain in the *Raw metadata table* for when the need arises. Additionnally, the user should filter out outliers which can be observed in the visualisation tab, or reduce the dataset if only a subset is to be examined.  
 This table can be accessed in the Omics_data object thus:  
 ```
 Omics_data$tables$meta_filtered
 ```
+</details>

--- a/help/tables_non_samples.md
+++ b/help/tables_non_samples.md
@@ -1,0 +1,16 @@
+Non-sample tables
+=======================
+---
+
+Tables containing data relating to non-samples (blanks, QCs and pools) stored in the Omics_data class.  
+<details>
+<summary><b> Blank table </b></summary>
+
+Contains the raw blank values from the imported lipidomics *Raw data table* but with the ID column set as in the *Filtered data table*. Since non-samples should be removed from the *Filtered data table*, the blank values are kept in this table for operations like blank filtering.  
+
+The table can be accessed in the Omics_data object thus:  
+```
+Omics_data$tables$blank_table
+```
+It is first initiated when the user uploads their lipidomics data table in the *Lipidomics upload* tab.  
+</details>

--- a/help/tables_plots.md
+++ b/help/tables_plots.md
@@ -3,18 +3,23 @@ Plot tables
 ---
 
 Tables related to the plot data, stored in the Omics_data class.  
-
-### Class distribution table
+<details>
+<summary> <b>Class distribution table</b> </summary>
 
 ```
 Omics_data$tables$class_distribution_table
 ```
+</details>
 
-### Class comparison tables
+<details>
+<summary> <b>Class comparison tables</b> </summary>
 
+Truffles
+</details>
 
+<details>
+<summary> <b>Volcano table</b> </summary>
 
-### Volcano table
 Table used to produce the volcano plot. Takes as input the *lipidomics table filtered* and the *lipidomics table z-score normalised*. Both these tables contain NA values, and the z-scoring on the latter is done by omiting NAs.  
 Two groups are selected by the user to compare their features by calculating their fold changes on the *lipidomics table filtered* (median(group_2) / median(group_1)) and their p-values on *lipidomics table z-score normalised* using a Wilcoxon test.  
 The p-values are then adjusted using the Benjamini-Hochberg procedure (BH). A table is then created with the lipid species as rows, with for columns log2(fold change), -log10(BH adjusted p-value) and the lipid class associated to each row.  
@@ -27,14 +32,19 @@ The p-values are then adjusted using the Benjamini-Hochberg procedure (BH). A ta
 ```
 Omics_data$tables$volcano_table
 ```
+</details>
 
-### Heatmap table
+<details>
+<summary> <b>Heatmap table</b> </summary>
 
 ```
 Omics_data$tables$heatmap_table
 ```
+</details>
 
-### PCA tables
+<details>
+<summary> <b>PCA tables</b> </summary>
+
 
 ```
 Omics_data$tables$pca_scores_table
@@ -42,9 +52,12 @@ Omics_data$tables$pca_scores_table
 ```
 Omics_data$tables$pca_loadings_table
 ```
+</details>
 
-### Double bonds table
+<details>
+<summary> <b>Double bonds table</b> </summary>
 
 ```
 Omics_data$tables$dbplot_table
 ```
+</details>


### PR DESCRIPTION
Documentation for blank tables added.
Data processing for the Blank and group filtering added in the Lipidomics filtering help tab. Folding menus added (bold, not h3, which makes the UI bug) Added groups to the volcano and double bonds plots names. Addition to volcano and double bonds plots. If the class normalised or the total normalised tables are chosen as input, their respective z-scored versions are also used for the p-value instead of just the simple z-scoredtable.