### PR TITLE
Patch 0.3.05 - Proteomics upload and Volcano table bug

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,3 +1,3 @@
 Package: soda
 Title: Simple Omics Data Analysis
-Version: 0.3.04
+Version: 0.3.05

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,3 +1,3 @@
 Package: soda
 Title: Simple Omics Data Analysis
-Version: 0.3.03
+Version: 0.3.04

--- a/R/lips_data_class.R
+++ b/R/lips_data_class.R
@@ -311,7 +311,7 @@ Lips_data = R6::R6Class(
         table = table[rownames(self$tables$meta_filtered),]
         table = remove_empty_cols(table)
       }
-
+      
       # Coerce to numeric matrix and save
       table = as.matrix(table)
       class(table) = "numeric"
@@ -403,7 +403,7 @@ Lips_data = R6::R6Class(
 
     # Volcano table
     get_volcano_table = function(data_table = self$tables$data_filtered, volcano_table = self$tables$feat_filtered, col_group = self$texts$col_group, used_function = "median", group_1, group_2) {
-
+      
       # Set the averaging function
       if (used_function == "median") {
         av_function = function(x) {return(median(x, na.rm = T))}
@@ -430,8 +430,12 @@ Lips_data = R6::R6Class(
       data_table = data_table[idx_all,]
       
       # Remove empty columns
+      dead_features = colnames(data_table)
       data_table = remove_empty_cols(table = data_table)
-
+      dead_features = setdiff(dead_features, colnames(data_table))
+      dead_features = which(rownames(volcano_table) %in% dead_features)
+      volcano_table = volcano_table[-dead_features,]
+      
       # Collect fold change and p-values
       fold_change = c()
       p_value = c()
@@ -475,8 +479,6 @@ Lips_data = R6::R6Class(
 
       # Adjust p-value
       p_value_bh_adj = p.adjust(p_value, method = "BH")
-
-      
       
       volcano_table$fold_change = fold_change
       volcano_table$p_value = p_value
@@ -626,7 +628,7 @@ Lips_data = R6::R6Class(
       
       # Create feature table
       self$set_feat_filtered()
-      
+
       # Class table
       self$class_grouping_raw()
       self$class_grouping_total_norm()

--- a/R/lips_plotboxes.R
+++ b/R/lips_plotboxes.R
@@ -437,8 +437,7 @@ volcano_plot_events = function(r6, dimensions_obj, colour_list, input, output, s
     r6$params$volcano_plot$classes = input$volcano_plot_lipclass
     r6$params$volcano_plot$selected_function = input$volcano_plot_function
     r6$params$volcano_plot$colouring = input$volcano_plot_colouring
-    
-    
+
     volcano_plot_generate(r6, colour_list, dimensions_obj, input)
     volcano_plot_spawn(r6, output)
   })

--- a/R/lips_upload.R
+++ b/R/lips_upload.R
@@ -832,6 +832,7 @@ soda_upload_lips_server = function(id, max_rows = 10, max_cols = 8, r6) {
               
               # Produce ensuing tables
               r6$set_all_tables()
+
               
               # Update the class filter
               shiny::updateSelectizeInput(


### PR DESCRIPTION
Improved proteomics feature metadata upload. Not only can this now be retrieved from uniprot, but the generated table can now be downloaded and reuploaded into the app instead of retrieving the data everytime.
Solved a minor bug which did not take into account empty columns in groups for the volcano table while filtering these dead columns into data table, leading to a discrepancy in columns.